### PR TITLE
Update base URL in index.html for subdirectory hosting

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BeyondTheLabel</title>
-    <base href="/" />
+    <base href="/beyondthelabel/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/app.css" />


### PR DESCRIPTION
Changed the <base> tag's href attribute in index.html from "/" to "/beyondthelabel/" to ensure all relative URLs resolve correctly when the application is hosted in the subdirectory "beyondthelabel".