### PR TITLE
Update base URL in <base> tag from /beyondthelabel/ to /app/

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BeyondTheLabel</title>
-    <base href="/beyondthelabel/" />
+    <base href="/app/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/app.css" />


### PR DESCRIPTION
Changed the <base> tag's href attribute to update the base URL for all relative URLs in the document. This change ensures that any relative links in the HTML file will now be resolved relative to /app/ instead of /beyondthelabel/. This could be part of a reorganization of the project's directory structure or a change in the deployment path.