### PR TITLE
Update base paths for static assets and service worker

### DIFF
--- a/BeyondTheLabel.csproj
+++ b/BeyondTheLabel.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	 <StaticWebAssetBasePath>app/</StaticWebAssetBasePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/wwwroot/service-worker.published.js
+++ b/wwwroot/service-worker.published.js
@@ -13,7 +13,7 @@ const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, 
 const offlineAssetsExclude = [ /^service-worker\.js$/ ];
 
 // Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.
-const base = "/app/";
+const base = "/";
 const baseUrl = new URL(base, self.origin);
 const manifestUrlList = self.assetsManifest.assets.map(asset => new URL(asset.url, baseUrl).href);
 


### PR DESCRIPTION
Added <StaticWebAssetBasePath>app/</StaticWebAssetBasePath> to BeyondTheLabel.csproj to set the base path for static web assets. Modified the base constant in service-worker.published.js from "/app/" to "/" to update the service worker's base path to the root directory.