### PR TITLE
Update service worker configuration and paths

### DIFF
--- a/BeyondTheLabel.csproj
+++ b/BeyondTheLabel.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	 <StaticWebAssetBasePath>app/</StaticWebAssetBasePath>
+	  <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,4 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0-preview.2.24128.4" PrivateAssets="all" />
   </ItemGroup>
 
+	<ItemGroup>
+		<ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
+	</ItemGroup>
 </Project>

--- a/wwwroot/service-worker.published.js
+++ b/wwwroot/service-worker.published.js
@@ -13,7 +13,7 @@ const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, 
 const offlineAssetsExclude = [ /^service-worker\.js$/ ];
 
 // Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.
-const base = "/";
+const base = "/app/";
 const baseUrl = new URL(base, self.origin);
 const manifestUrlList = self.assetsManifest.assets.map(asset => new URL(asset.url, baseUrl).href);
 


### PR DESCRIPTION
Replaced <StaticWebAssetBasePath> with <ServiceWorkerAssetsManifest> in .csproj. Added <ServiceWorker> element to include service-worker.js. Changed base path in service-worker.published.js to "/app/".