### PR TITLE
Simplify base href handling in deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,12 @@ jobs:
       # Publishes Blazor project to the release-folder
       - name: Publish .NET Core Project
         run: dotnet publish -c:Release -p:GHPages=true -o dist/BeyondTheLabel --nologo
+     
+      - name: Rewrite base href
+        uses: SteveSandersonMS/ghaction-rewrite-base-href@v1
+        with:
+          html_path: ${{ env.PUBLISH_DIR }}/index.html
+          base_href: /app/
 
       - name: Commit wwwroot to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Rewrite base href
         uses: SteveSandersonMS/ghaction-rewrite-base-href@v1
         with:
-          html_path: ${{ env.PUBLISH_DIR }}/index.html
+          html_path: dist/BeyondTheLabel/wwwroot/index.html
           base_href: /app/
 
       - name: Commit wwwroot to GitHub Pages

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -5,18 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BeyondTheLabel</title>
-    <base />
-    <script>
-        var path = window.location.pathname.split('/');
-        var base = document.getElementsByTagName('base')[0];
-        if (window.location.host.includes('localhost')) {
-            base.setAttribute('href', '/');
-        } else if (path.length > 2) {
-            base.setAttribute('href', '/' + path[1] + '/');
-        } else if (path[path.length - 1].length != 0) {
-            window.location.replace(window.location.origin + window.location.pathname + '/' + window.location.search);
-        }
-    </script>
+    <base href="/" />
+
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/app.css" />


### PR DESCRIPTION
Added a new step in `main.yml` to rewrite the base href in `index.html` using the `SteveSandersonMS/ghaction-rewrite-base-href` GitHub Action. This ensures the correct base URL is set for the application when deployed to GitHub Pages. Removed the manual script in `index.html` for setting the base href dynamically based on the environment, and set a static base href of "/" directly in the `<base>` tag.