### PR TITLE
Update service worker base path to "/app/"

### DIFF
--- a/wwwroot/service-worker.published.js
+++ b/wwwroot/service-worker.published.js
@@ -13,7 +13,7 @@ const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, 
 const offlineAssetsExclude = [ /^service-worker\.js$/ ];
 
 // Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.
-const base = "/";
+const base = "/app/";
 const baseUrl = new URL(base, self.origin);
 const manifestUrlList = self.assetsManifest.assets.map(asset => new URL(asset.url, baseUrl).href);
 


### PR DESCRIPTION
Changed the service worker's base path from "/" to "/app/" to ensure proper functionality and resource loading when the application is hosted in a subfolder named "app". This adjustment prefixes all URLs and paths managed by the service worker with "/app/".