### PR TITLE
Add StaticWebAssetBasePath property to .csproj

### DIFF
--- a/BeyondTheLabel.csproj
+++ b/BeyondTheLabel.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	  <StaticWebAssetBasePath>app</StaticWebAssetBasePath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The project file `BeyondTheLabel.csproj` has been modified to include a new property within the `<PropertyGroup>` section. Specifically, the `<StaticWebAssetBasePath>` property has been added with the value `app`. This change likely specifies a base path for static web assets in the Blazor WebAssembly project.