### PR TITLE
Update publish command and html_path in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Rewrite base href
         uses: SteveSandersonMS/ghaction-rewrite-base-href@v1
         with:
-          html_path: dist/BeyondTheLabel/wwwroot/index.html
+          html_path: dist/BeyondTheLabel/wwwroot/app/index.html
           base_href: /app/
 
       - name: Commit wwwroot to GitHub Pages


### PR DESCRIPTION
- Updated `dotnet publish` command in `main.yml` to include `-p:GHPages=true` and set output directory to `dist/BeyondTheLabel`.
- Changed `html_path` in `Rewrite base href` step from `dist/BeyondTheLabel/wwwroot/index.html` to `dist/BeyondTheLabel/wwwroot/app/index.html`.