### PR TITLE
Comment out base href rewrite step in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Publish .NET Core Project
         run: dotnet publish -c:Release -p:GHPages=true -o dist/BeyondTheLabel --nologo
      
-      - name: Rewrite base href
-        uses: SteveSandersonMS/ghaction-rewrite-base-href@v1
-        with:
-          html_path: dist/BeyondTheLabel/wwwroot/app/index.html
-          base_href: /app/
+      # - name: Rewrite base href
+      #   uses: SteveSandersonMS/ghaction-rewrite-base-href@v1
+      #   with:
+      #     html_path: dist/BeyondTheLabel/wwwroot/app/index.html
+      #     base_href: /app/
 
       - name: Commit wwwroot to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
The step that rewrites the base href in the GitHub Actions workflow has been commented out. This step used the
`SteveSandersonMS/ghaction-rewrite-base-href@v1` action to modify the `base_href` in the `index.html` file located at
`dist/BeyondTheLabel/wwwroot/app/index.html`. The rest of the workflow remains unchanged, including the steps to publish the .NET Core project and commit the `wwwroot` folder to GitHub Pages.