### PR TITLE
Remove background video from Home and index files

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -144,7 +144,7 @@
     <!-- Introduction Section with Video -->
     <section id="intro" class="intro-section">
         <!-- Video Background -->
-        <video autoplay loop muted playsinline class="background-video">
+        <video autoplay loop muted playsinline>
             <source src="media/videos/landing-page-video.mp4" type="video/mp4">
             Your browser does not support the video tag.
         </video>

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -24,10 +24,6 @@
 
 <body>
     <div id="app">
-        <video autoplay loop muted playsinline>
-            <source src="media/videos/landing-page-video.mp4" type="video/mp4">
-            Your browser does not support the video tag.
-        </video>
         <!-- Cute Loading Animation -->
         <div class="cute-loading">
             <img src="media/images/beyondthelabel.jpg" alt="Loading, please wait..." class="cute-loading-img" />


### PR DESCRIPTION
- Removed the `playsinline` attribute from the `<video>` tag in `Home.razor`.
- Deleted the entire `<video>` element from `index.html`, impacting the loading experience.