### PR TITLE
Update video element container selector

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -338,7 +338,7 @@
 
     // Append the video element to the DOM
     // For example, append it to the body or a specific container
-    const container = document.querySelector('body'); // Replace 'body' with your desired container selector
+    const container = document.querySelector('#video-container'); // Replace 'body' with your desired container selector
     container.appendChild(videoElement);
 
     }catch(error){


### PR DESCRIPTION
Changed the DOM selector for appending the video element from 'body' to '#video-container' for improved layout control.