### PR TITLE
Update image source paths to relative URLs

### DIFF
--- a/Pages/Research.razor
+++ b/Pages/Research.razor
@@ -13,7 +13,7 @@
 <div class="text-center research-container">
 
     <div>
-        <img id="research-banner" src="/media/images/research_1.png" alt="Speech Pathology Banner" class="img-fluid">
+        <img id="research-banner" src="media/images/research_1.png" alt="Speech Pathology Banner" class="img-fluid">
     </div>
 
     <section class="mt-2 text-center" id="research-body">
@@ -47,7 +47,7 @@
         </div>
 
         <div>
-            <img id="research-footer" src="/media/images/research_2.png" alt="Speech Pathology Footer" class="img-fluid">
+            <img id="research-footer" src="media/images/research_2.png" alt="Speech Pathology Footer" class="img-fluid">
         </div>
 
     </section>


### PR DESCRIPTION
Updated the `src` attributes for the research banner and footer images by removing the leading slash. The paths have been changed from absolute to relative, improving portability.